### PR TITLE
Fix construction of _normals in offset module

### DIFF
--- a/projects/clipper2-js/src/lib/offset.ts
+++ b/projects/clipper2-js/src/lib/offset.ts
@@ -400,9 +400,9 @@ export class ClipperOffset {
     this._normals.length = cnt;
 
     for (let i = 0; i < cnt - 1; i++) {
-      this._normals.push(ClipperOffset.getUnitNormal(path[i], path[i + 1]));
+      this._normals[i] = ClipperOffset.getUnitNormal(path[i], path[i + 1]);
     }
-    this._normals.push(ClipperOffset.getUnitNormal(path[cnt - 1], path[0]));
+    this._normals[cnt - 1] = ClipperOffset.getUnitNormal(path[cnt - 1], path[0]);
   }
 
   crossProduct(vec1: PointD, vec2: PointD): number {

--- a/projects/clipper2-js/tests/offset.test.ts
+++ b/projects/clipper2-js/tests/offset.test.ts
@@ -1,0 +1,23 @@
+import { Paths64, Clipper, JoinType, EndType } from '../src/public-api';
+
+describe('InflatePaths', () => {
+  it('offsets an open line', () => {
+    const paths = new Paths64();
+    paths.push(Clipper.makePath([0, 0, 10, 0]))
+
+    const inflatedPaths = Clipper.InflatePaths(
+      paths,
+      1,
+      JoinType.Miter,
+      EndType.Butt,
+    );
+
+    expect(inflatedPaths).toEqual([[
+      { x: 10, y: 1, },
+      { x: -0, y: 1, },
+      { x: -0, y: -1, },
+      { x: 10, y: -1, },
+    ]]);
+  })
+
+})


### PR DESCRIPTION
Solves #1.

This function set the length of the `_normals` array, and then proceeded to push to it. This leads to inflated indices in JavaScript, for example:

```js
const arr = [];
arr.length = 2;
arr.push("peekaboo!");
console.log(arr[0]); // -> undefined
console.log(arr[1]); // -> 'peekaboo!'
```

This means the indexing of the normals doesn't match up with that of the points, which causes a crash.

I added a very simple regression test, although I didn't take the time to understand the test setup you have with `ClipperParse` so it doesn't follow that same format. Feel free to edit if you're not happy with that.